### PR TITLE
8494-update-swagger-release-2023-09-07

### DIFF
--- a/doc/assetv2/creation.rst
+++ b/doc/assetv2/creation.rst
@@ -11,7 +11,7 @@ Define the asset parameters and store in /path/to/jsonfile:
 .. code-block:: JSON
 
     {
-        "behaviours": ["Firmware", "Maintenance", "RecordEvidence", "LocationUpdate", "Attachments"],
+        "behaviours": ["RecordEvidence"],
         "attributes": {
             "arc_firmware_version": "1.0",
             "arc_serial_number": "vtl-x4-07",
@@ -63,11 +63,7 @@ The response is:
     {
         "identity": "assets/3f5be24f-fd1b-40e2-af35-ec7c14c74d53",
         "behaviours": [
-            "Firmware",
-            "Maintenance",
-            "RecordEvidence",
-            "LocationUpdate",
-            "Attachments"
+            "RecordEvidence"
         ],
         "attributes": {
             "arc_serial_number": "vtl-x4-07",

--- a/doc/openapi/assetsv2.swagger.json
+++ b/doc/openapi/assetsv2.swagger.json
@@ -950,8 +950,7 @@
       "type": "object",
       "example": {
         "behaviours": [
-          "RecordEvidence",
-          "Attachments"
+          "RecordEvidence"
         ],
         "attributes": {
           "arc_firmware_version": "3.2.1",


### PR DESCRIPTION
This is a result of manually performing the "update docs" avid CD pipeline step using the docs artefact from from this avid CI run: https://dev.azure.com/jitsuin/avid/_build/results?buildId=67441&view=results.

The same rsync command was used as in the pipeline (adjusted for my local checkout directory):
rsync -aP --delete sphinx_doc/ $HOME/git/archivist-docs/doc

fixes [AB#8494](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8494)

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>